### PR TITLE
Fixed a typo which prevents `stack install` from working

### DIFF
--- a/src/InteractiveUI.hs
+++ b/src/InteractiveUI.hs
@@ -3650,7 +3650,7 @@ tryBool m = do
 -- Utils
 
 lookupModule :: GHC.GhcMonad m => String -> m Module
-lookupModule mName = lookupModuleName GHC.mkModuleName mName)
+lookupModule mName = lookupModuleName (GHC.mkModuleName mName)
 
 lookupModuleName :: GHC.GhcMonad m => ModuleName -> m Module
 lookupModuleName mName = GHC.lookupModule mName Nothing


### PR DESCRIPTION
This issue came from here: https://github.com/myfreeweb/intero/commit/4e527e6a893cc3623603f3d0a2d3006a18086ad1#diff-a469118375854c9ae9408cbd3bb03b39L3594
